### PR TITLE
fix: update networking for Yacht

### DIFF
--- a/ansible/templates/yacht-stack.yml.j2
+++ b/ansible/templates/yacht-stack.yml.j2
@@ -3,7 +3,7 @@ volumes:
     driver: local
     name: yacht_config
 networks:
-  neon-core:
+  neon_neon-core:
     external: true
 
 services:
@@ -11,6 +11,10 @@ services:
     image: selfhostedpro/yacht
     restart: unless-stopped
     container_name: yacht
+    networks:
+      neon_neon-core:
+        aliases:
+          - yacht
     ports:
       - 8000:8000
     volumes:


### PR DESCRIPTION
# Description
If Yacht isn't on the correct network, the NGINX service fails because it can't find it.

# Issues
N/A

# Other Notes
Pretty major bug. I tested this configuration on my Hub and it solved the problem.