### PR TITLE
feat: add mDNS service advertisement via Avahi (CO1 2.1)

### DIFF
--- a/debos/overlays/ansible/hub.yaml
+++ b/debos/overlays/ansible/hub.yaml
@@ -96,7 +96,7 @@
     # Prepare
     - name: Ensure package prerequisites are installed
       ansible.builtin.package:
-        name: openssl,python3-docker,python3-jsondiff,ffmpeg
+        name: openssl,python3-docker,python3-jsondiff,ffmpeg,avahi-daemon
         state: present
     - name: Get primary IP address
       ansible.builtin.set_fact:
@@ -251,6 +251,15 @@
           127.0.0.1    iris-websat.{{ common_name }}
           127.0.0.1    rmq-admin.{{ common_name }}
           127.0.0.1    config.{{ common_name }}
+    # mDNS service advertisement
+    - name: Copy Avahi service definition
+      ansible.builtin.template:
+        src: templates/neon-hub.service.j2
+        dest: /etc/avahi/services/neon-hub.service
+        mode: "0644"
+        owner: root
+        group: root
+      notify: Restart avahi-daemon
     # Neon Node Client
     - name: Install Neon Node Client
       import_tasks: neon-node.yaml
@@ -284,3 +293,10 @@
       ansible.builtin.debug:
         msg: "Rebooting the system now, as requested."
       when: start_neon_hub_services == "1" and reboot_answer.user_input | lower in ['yes', 'y']
+
+  handlers:
+    - name: Restart avahi-daemon
+      ansible.builtin.systemd:
+        name: avahi-daemon
+        state: restarted
+        enabled: true

--- a/debos/overlays/ansible/templates/neon-hub.service.j2
+++ b/debos/overlays/ansible/templates/neon-hub.service.j2
@@ -1,0 +1,11 @@
+<?xml version="1.0" standalone='no'?>
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+  <name replace-wildcards="yes">Neon Hub on %h</name>
+  <service>
+    <type>_neon-hub._tcp</type>
+    <port>8082</port>
+    <txt-record>path=/api</txt-record>
+    <txt-record>hostname={{ common_name }}</txt-record>
+  </service>
+</service-group>

--- a/docs/service-details.md
+++ b/docs/service-details.md
@@ -6,6 +6,37 @@ Neon Hub is more than just a voice assistant. It is a collection of services tha
 
 Neon Hub leverages Docker Compose for container management. Service start/stop/restart is handled via `docker compose` from `/home/neon/compose` on the Hub itself.
 
+## Network Discovery (mDNS)
+
+Neon Hub advertises itself on the local network using [Avahi](https://avahi.org/), an mDNS/DNS-SD service. This allows Neon Node apps to automatically discover available Hubs on the same network using the "Scan for Hubs" feature.
+
+The Hub advertises as service type `_neon-hub._tcp` on port 8082 (the HANA API endpoint).
+
+### Verifying discovery
+
+From a Linux machine on the same network:
+
+```bash
+avahi-browse -r _neon-hub._tcp
+```
+
+From a macOS machine:
+
+```bash
+dns-sd -B _neon-hub._tcp local.
+```
+
+You should see your Hub appear with its hostname and port.
+
+### Troubleshooting discovery
+
+If your Hub is not discoverable:
+
+1. Verify avahi-daemon is running: `systemctl status avahi-daemon`
+2. Check the service file exists: `ls /etc/avahi/services/neon-hub.service`
+3. Ensure your firewall allows mDNS traffic (UDP port 5353)
+4. Verify the Hub and the scanning device are on the same network/subnet
+
 ## Configuration tool
 
 Neon Hub ships with a configuration tool that simplifies common tasks such as changing log levels, adding your own API keys for external services, and customizing other services. This tool is available at `https://neon-hub.local`.


### PR DESCRIPTION
## Summary

- Configures Avahi to advertise the Hub as `_neon-hub._tcp` on port 8082, enabling the Neon Node app's "Scan for Hubs" feature to discover Hubs on the local network without manual IP entry
- Adds `avahi-daemon` to package prerequisites and an Ansible handler to restart the service on config changes
- Adds Network Discovery documentation to `service-details.md` with verify/troubleshoot instructions for Linux and macOS

## Files changed

- `debos/overlays/ansible/hub.yaml` — avahi-daemon package, service template task, restart handler
- `debos/overlays/ansible/templates/neon-hub.service.j2` — Avahi service definition (new)
- `docs/service-details.md` — Network Discovery section

## Test plan

- [ ] Run installer on a clean Hub — verify `avahi-daemon` is installed and running
- [ ] Verify `avahi-browse -r _neon-hub._tcp` discovers the Hub from another machine on the same network
- [ ] Verify `dns-sd -B _neon-hub._tcp` works from macOS
- [ ] Verify TXT records contain `path=/api` and correct hostname