### PR TITLE
fix: use the neongeckocom image for neon-hub-config

### DIFF
--- a/debos/overlays/ansible/templates/neon-hub.yml.j2
+++ b/debos/overlays/ansible/templates/neon-hub.yml.j2
@@ -375,7 +375,7 @@ services:
     restart: unless-stopped
     depends_on:
       - hana
-    image: ghcr.io/oscillatelabsllc/neon-hub-config:main # TODO: Move to NeonGeckoCom
+    image: ghcr.io/neongeckocom/neon-hub-config:main
     environment:
       DIANA_PATH: /root/.config/neon/diana.yaml
       NEON_PATH: /root/.config/neon/neon.yaml


### PR DESCRIPTION
Choose the correct location for the neon-hub-config image, after it migrated to the NeonGeckoCom org.