### PR TITLE
feat(mdns): advertise reverse-proxy via mDNS so Nodes can auto-connect over TLS

### DIFF
--- a/debos/overlays/ansible/files/avahi-alias-hana-resolve
+++ b/debos/overlays/ansible/files/avahi-alias-hana-resolve
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Pick the IPv4 that owns the default route — the same source as
+# ansible's `ansible_default_ipv4.address` fact. Re-run on every
+# unit start so DHCP renewals or network swaps land cleanly.
+#
+# Output: writes PRIMARY_IP=<addr> to /run/avahi-alias-hana.env
+# for the systemd unit's EnvironmentFile to consume.
+set -e
+IP=$(ip -4 route get 1.1.1.1 2>/dev/null | awk '{print $7; exit}')
+if [ -z "$IP" ]; then
+    echo "avahi-alias-hana-resolve: could not determine primary IPv4" >&2
+    exit 1
+fi
+mkdir -p /run
+printf 'PRIMARY_IP=%s\n' "$IP" > /run/avahi-alias-hana.env

--- a/debos/overlays/ansible/hub.yaml
+++ b/debos/overlays/ansible/hub.yaml
@@ -104,7 +104,7 @@
     # Prepare
     - name: Ensure package prerequisites are installed
       ansible.builtin.package:
-        name: openssl,python3-docker,python3-jsondiff,ffmpeg,avahi-daemon
+        name: openssl,python3-docker,python3-jsondiff,ffmpeg,avahi-daemon,avahi-utils
         state: present
     - name: Get primary IP address
       ansible.builtin.set_fact:
@@ -306,6 +306,33 @@
         owner: root
         group: root
       notify: Restart avahi-daemon
+    # mDNS alias for the proxy hostname (hana.{{ common_name }}).
+    # Avahi only auto-advertises the host's own hostname (%h), so
+    # without this the cert-subject hostname has no A record on the
+    # wire and clients can't validate TLS. A small systemd unit runs
+    # `avahi-publish-address` to claim the alias for the lifetime
+    # of avahi-daemon.
+    - name: Install hana mDNS alias resolver helper
+      ansible.builtin.copy:
+        src: files/avahi-alias-hana-resolve
+        dest: /usr/local/sbin/avahi-alias-hana-resolve
+        mode: "0755"
+        owner: root
+        group: root
+    - name: Install hana mDNS alias systemd unit
+      ansible.builtin.template:
+        src: templates/avahi-alias-hana.service.j2
+        dest: /etc/systemd/system/avahi-alias-hana.service
+        mode: "0644"
+        owner: root
+        group: root
+      notify: Restart avahi-alias-hana
+    - name: Enable and start hana mDNS alias
+      ansible.builtin.systemd:
+        name: avahi-alias-hana
+        enabled: true
+        state: started
+        daemon_reload: true
     # Neon Node Client
     - name: Install Neon Node Client
       import_tasks: neon-node.yaml
@@ -346,3 +373,9 @@
         name: avahi-daemon
         state: restarted
         enabled: true
+    - name: Restart avahi-alias-hana
+      ansible.builtin.systemd:
+        name: avahi-alias-hana
+        state: restarted
+        enabled: true
+        daemon_reload: true

--- a/debos/overlays/ansible/templates/avahi-alias-hana.service.j2
+++ b/debos/overlays/ansible/templates/avahi-alias-hana.service.j2
@@ -1,0 +1,32 @@
+[Unit]
+Description=Publish hana.{{ common_name }} as an mDNS alias
+# Bind to avahi-daemon so the alias goes down when avahi does, and
+# wait for the network to be online so ExecStartPre can pick up an
+# IPv4 address from the default route.
+Requires=avahi-daemon.service
+After=avahi-daemon.service network-online.target
+BindsTo=avahi-daemon.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+# Re-resolve the primary IPv4 on every (re)start so a DHCP-renewed
+# or interface-swapped IP lands cleanly. The helper writes the
+# current address into PRIMARY_IP for ExecStart to consume.
+ExecStartPre=/usr/local/sbin/avahi-alias-hana-resolve
+EnvironmentFile=/run/avahi-alias-hana.env
+# -R skips avahi's local conflict check. Without it, the publish
+# fails with "Local name collision" even though no peer on the LAN
+# is actually claiming the name. Source of the apparent conflict
+# isn't fully understood — we ruled out the /etc/hosts entry by
+# commenting it out and reproducing — and may be avahi hearing its
+# own multicast announcement reflected back across one of the many
+# docker veth interfaces the hub typically has. Skipping the check
+# is safe here: no real peer publishes this name, so there's no
+# actual conflict to detect.
+ExecStart=/usr/bin/avahi-publish-address -R hana.{{ common_name }} ${PRIMARY_IP}
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/debos/overlays/ansible/templates/neon-hub.service.j2
+++ b/debos/overlays/ansible/templates/neon-hub.service.j2
@@ -4,8 +4,8 @@
   <name replace-wildcards="yes">Neon Hub on %h</name>
   <service>
     <type>_neon-hub._tcp</type>
-    <port>8082</port>
-    <txt-record>path=/api</txt-record>
-    <txt-record>hostname={{ common_name }}</txt-record>
+    <port>443</port>
+    <txt-record>scheme=https</txt-record>
+    <txt-record>host=hana.{{ common_name }}</txt-record>
   </service>
 </service-group>

--- a/docs/service-details.md
+++ b/docs/service-details.md
@@ -12,17 +12,24 @@ Neon Hub ships with [Simple Docker Manager](https://github.com/OscillateLabsLLC/
 
 ## Network Discovery (mDNS)
 
-Neon Hub advertises itself on the local network using [Avahi](https://avahi.org/), an mDNS/DNS-SD service. This allows Neon Node apps to automatically discover available Hubs on the same network using the "Scan for Hubs" feature.
+Neon Hub advertises itself on the local network using [Avahi](https://avahi.org/), an mDNS/DNS-SD responder. This allows Neon Node apps to automatically discover available Hubs on the same network using the "Scan for Hubs" feature. The installer pulls in `avahi-daemon` and `avahi-utils` as required packages — if you weren't already running them, expect a small added footprint.
 
-The Hub advertises as service type `_neon-hub._tcp` on port 8082 (the HANA API endpoint).
+The Hub advertises as service type `_neon-hub._tcp` on port 443 (the public reverse-proxy endpoint, same one that serves `https://hana.<common_name>`). The service record carries two TXT entries:
+
+- `scheme=https` — the URL scheme clients should use.
+- `host=hana.<common_name>` — the cert-subject hostname clients should use for SNI and the `Host` header. Defaults to `hana.neon-hub.local`.
+
+The Hub also publishes `hana.<common_name>` as an mDNS A-record alias (via a small `avahi-publish-address` systemd unit, `avahi-alias-hana.service`) so off-hub clients can resolve the cert-subject name and validate TLS without falling back to the trust-on-first-use path. Without this alias, only the host's own `%h` name (e.g. `neon-hub.local`) would be visible on the wire.
 
 ### Verifying discovery
 
 From a Linux machine on the same network:
 
 ```bash
-avahi-browse -r _neon-hub._tcp
+avahi-browse -rt _neon-hub._tcp
 ```
+
+You should see a resolved (`=`) record with `port=443` and both TXT entries populated.
 
 From a macOS machine:
 
@@ -30,16 +37,23 @@ From a macOS machine:
 dns-sd -B _neon-hub._tcp local.
 ```
 
-You should see your Hub appear with its hostname and port.
+To confirm the proxy hostname resolves over mDNS:
+
+```bash
+avahi-resolve-host-name -4 hana.neon-hub.local
+```
+
+This should return the Hub's primary IPv4 address.
 
 ### Troubleshooting discovery
 
 If your Hub is not discoverable:
 
 1. Verify avahi-daemon is running: `systemctl status avahi-daemon`
-2. Check the service file exists: `ls /etc/avahi/services/neon-hub.service`
-3. Ensure your firewall allows mDNS traffic (UDP port 5353)
-4. Verify the Hub and the scanning device are on the same network/subnet
+2. Verify the alias unit is running: `systemctl status avahi-alias-hana`
+3. Check the service file exists: `ls /etc/avahi/services/neon-hub.service`
+4. Ensure your firewall allows mDNS traffic (UDP port 5353)
+5. Verify the Hub and the scanning device are on the same network/subnet
 
 ## Configuration tool
 


### PR DESCRIPTION
Closes #26.

## Problem

The default `neon-hub.service` mDNS announcement pointed at the inner Hana container (`port 8082`, `path=/api`, `hostname=neon-hub.local`). That address skips the reverse proxy, so a discovering Node never reaches the public `https://hana.<common_name>` host the TLS cert is issued for, gets a misleading `path=/api` TXT record, and ends up at port 8082, which isn't exposed outside the host in a normal deployment.

## Fix

Two halves, both required for clients to actually connect over TLS without a trust-on-first-use prompt.

**1. Service record points at the proxy.** The service announces `port 443` and carries TXT records `scheme=https` and `host=hana.<common_name>`. It resolves via `%h` (the host's own mDNS A record), giving clients a real IP, while the TXT `host=` carries the cert-subject hostname for SNI and the `Host` header. Standard "network host ≠ cert subject" pattern.

**2. Publish `hana.<common_name>` as an mDNS A-record alias.** A small systemd unit (`avahi-alias-hana.service`) runs `avahi-publish-address` to claim the alias for the lifetime of avahi-daemon, and re-resolves the primary IPv4 on every (re)start so DHCP renewals land cleanly. Without this, the cert-subject hostname has no A record on the wire and clients fall back to a self-signed-cert prompt despite the cert being perfectly valid.

The `-R` flag is required because without it the publish fails with "Local name collision" even though no peer on the LAN is claiming the name. The source of the apparent conflict isn't fully understood (we ruled out the `/etc/hosts` entry by commenting it out and reproducing) and may be avahi hearing its own multicast announcement reflected back across one of the many docker veth interfaces the hub typically has. Skipping the check is safe here because no real peer publishes this name.

## Dependencies

`avahi-utils` is added to the prereq package list alongside the existing `avahi-daemon`. Hubs not previously running avahi will see a small new package footprint; this is now documented in `docs/service-details.md`.

## Verification

```
$ avahi-browse -rtp _neon-hub._tcp
+;eno1;IPv6;Neon\032Hub\032on\032neon-hub;_neon-hub._tcp;local
+;eno1;IPv4;Neon\032Hub\032on\032neon-hub;_neon-hub._tcp;local
=;eno1;IPv6;Neon\032Hub\032on\032neon-hub;_neon-hub._tcp;local;neon-hub.local;<v6>;443;"host=hana.neon-hub.local" "scheme=https"
=;eno1;IPv4;Neon\032Hub\032on\032neon-hub;_neon-hub._tcp;local;neon-hub.local;192.168.86.63;443;"host=hana.neon-hub.local" "scheme=https"

$ avahi-resolve-host-name -4 hana.neon-hub.local
hana.neon-hub.local    192.168.86.63
```

Both browse and resolve work cleanly on a LAN peer; `hana.neon-hub.local` resolves to the hub's IP from outside the hub itself.