### PR TITLE
fix: skip audio wiring on hosts without ALSA

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,6 @@
+profile: basic
+exclude_paths:
+  # debos recipes are Go-templated YAML, not Ansible
+  - debos/hub-efi.yaml
+  - debos/recipes/
+  - windows/

--- a/.ansible-lint-ignore
+++ b/.ansible-lint-ignore
@@ -1,0 +1,14 @@
+# This file contains ignores rule violations for ansible-lint
+debos/overlays/ansible/generate-certificate.yaml name[template]
+debos/overlays/ansible/generate-certificate.yaml yaml[truthy]
+debos/overlays/ansible/generate-secrets.yaml yaml[line-length]
+debos/overlays/ansible/hub.yaml command-instead-of-module
+debos/overlays/ansible/hub.yaml command-instead-of-shell
+debos/overlays/ansible/hub.yaml name[template]
+debos/overlays/ansible/hub.yaml yaml[truthy]
+debos/overlays/ansible/kiosk-teardown.yaml command-instead-of-shell
+debos/overlays/ansible/kiosk-teardown.yaml yaml[truthy]
+debos/overlays/ansible/kiosk.yaml yaml[truthy]
+debos/overlays/ansible/neon-node.yaml command-instead-of-module
+debos/overlays/ansible/neon-node.yaml yaml[indentation]
+debos/overlays/ansible/neon-node.yaml yaml[octal-values]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+---
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  ansible:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+          cache: pip
+          cache-dependency-path: tests/requirements.txt
+      - name: Install ansible tooling
+        run: pip install -r tests/requirements.txt
+      - name: Cache galaxy requirements
+        uses: actions/cache@v6
+        with:
+          path: ~/.ansible
+          key: galaxy-${{ hashFiles('debos/overlays/ansible/requirements.yml') }}
+      - name: Install galaxy requirements
+        run: ansible-galaxy install -r debos/overlays/ansible/requirements.yml
+      - name: Lint
+        run: ansible-lint
+      - name: Syntax check
+        run: ansible-playbook --syntax-check -i 127.0.0.1, debos/overlays/ansible/hub.yaml
+      - name: Compose template render test
+        run: ansible-playbook tests/render_test.yml

--- a/debos/overlays/ansible/hub.yaml
+++ b/debos/overlays/ansible/hub.yaml
@@ -325,6 +325,21 @@
     - name: Parse .env file
       ansible.builtin.set_fact:
         env_vars: "{{ (env_file['content'] | b64decode).split('\n') | select('match', '^(?!#).*=.*') | list }}"
+    # Cloud kernels (AWS linux-aws and similar) ship without ALSA, so binding
+    # /dev/snd fails the audio containers. Probe only on a live install: debos
+    # builds lack /dev/snd but their target hardware has it.
+    - name: Check for ALSA sound devices
+      ansible.builtin.stat:
+        path: /dev/snd/timer
+      register: alsa_timer
+      when:
+        - ansible_system == 'Linux'
+        - start_neon_hub_services == "1"
+        - hub_has_audio is not defined
+    - name: Default hub audio support from ALSA probe
+      ansible.builtin.set_fact:
+        hub_has_audio: "{{ alsa_timer.stat.exists | default(true) }}"
+      when: hub_has_audio is not defined
     - name: Copy compose file from template
       ansible.builtin.template:
         src: templates/neon-hub.yml.j2

--- a/debos/overlays/ansible/templates/neon-hub.yml.j2
+++ b/debos/overlays/ansible/templates/neon-hub.yml.j2
@@ -105,7 +105,9 @@ services:
 {% if ansible_system == 'Linux' %}
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
+{% if hub_has_audio | default(true) | bool %}
       - /home/${NEON_USER}/.config/pulse/cookie:/xdg/config/pulse/cookie:ro
+{% endif %}
 {% endif %}
       - ${NEON_CONFIG_FOLDER}:/xdg/config:ro
       - listener_records:/xdg/local/share/neon/listener
@@ -114,7 +116,7 @@ services:
       - vosk:/xdg/local/share/vosk
     environment:
       <<: *default-env-vars
-{% if ansible_system == 'Linux' %}
+{% if ansible_system == 'Linux' and hub_has_audio | default(true) | bool %}
     devices:
       - /dev/snd
 {% endif %}
@@ -131,7 +133,9 @@ services:
     volumes:
 {% if ansible_system == 'Linux' %}
       - ${XDG_RUNTIME_DIR}/bus:${XDG_RUNTIME_DIR}/bus:ro
+{% if hub_has_audio | default(true) | bool %}
       - /home/${NEON_USER}/.config/pulse/cookie:/xdg/config/pulse/cookie:ro
+{% endif %}
 {% endif %}
       - ${NEON_CONFIG_FOLDER}:/xdg/config
       - ${NEON_LOCAL_FOLDER}:/xdg/local
@@ -146,7 +150,7 @@ services:
       DBUS_SESSION_BUS_ADDRESS: unix:path=${XDG_RUNTIME_DIR}/bus
 {% endif %}
       LOG_LEVEL: INFO
-{% if ansible_system == 'Linux' %}
+{% if ansible_system == 'Linux' and hub_has_audio | default(true) | bool %}
     devices:
       - /dev/snd
 {% endif %}
@@ -162,7 +166,9 @@ services:
       neon-core:
     volumes:
 {% if ansible_system == 'Linux' %}
+{% if hub_has_audio | default(true) | bool %}
       - ${XDG_RUNTIME_DIR}/pulse/cookie:${XDG_RUNTIME_DIR}/pulse/cookie:ro
+{% endif %}
       - ${XDG_RUNTIME_DIR}/bus:${XDG_RUNTIME_DIR}/bus:ro
       - /tmp/.X11-unix:/tmp/.X11-unix:ro
 {% endif %}
@@ -178,7 +184,7 @@ services:
       DISPLAY: ${DISPLAY}
       DBUS_SESSION_BUS_ADDRESS: unix:path=${XDG_RUNTIME_DIR}/bus
 {% endif %}
-{% if ansible_system == 'Linux' %}
+{% if ansible_system == 'Linux' and hub_has_audio | default(true) | bool %}
     devices:
       - /dev/snd
 {% endif %}
@@ -193,7 +199,7 @@ services:
     networks:
       neon-core:
     volumes:
-{% if ansible_system == 'Linux' %}
+{% if ansible_system == 'Linux' and hub_has_audio | default(true) | bool %}
       - /home/${NEON_USER}/.config/pulse/cookie:/xdg/config/pulse/cookie:ro
 {% endif %}
       - ${NEON_CONFIG_FOLDER}:/xdg/config
@@ -204,7 +210,7 @@ services:
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
 {% endif %}
-{% if ansible_system == 'Linux' %}
+{% if ansible_system == 'Linux' and hub_has_audio | default(true) | bool %}
     devices:
       - /dev/snd
 {% endif %}

--- a/docs/cloud-vps.md
+++ b/docs/cloud-vps.md
@@ -96,6 +96,14 @@ The installer walks you through a guided setup. When it asks for a hostname, use
 
 See [Installation](installation.md) for what the installer prompts cover and what you can change later.
 
+### No sound hardware on cloud kernels
+
+Cloud-optimized kernels (AWS `linux-aws`, and similar builds on other providers) ship without ALSA. `/dev/snd` does not exist and cannot be created with `modprobe`, because the sound modules are not compiled for these kernels at all.
+
+The installer detects this and generates a compose file without sound-device wiring. Nothing is lost in practice. STT, TTS, and wake word are served to Nodes over the network, and a cloud Hub has no microphone or speaker to drive anyway.
+
+To force the detection either way, pass `hub_has_audio=true` or `false` as an Ansible extra variable. If you see `error gathering device information while adding custom device "/dev/snd"` during install, you are running an installer version that predates this detection. Update and re-run.
+
 ## Validating the install
 
 After `installer.sh` finishes, hit HANA from your admin workstation:

--- a/tests/render_test.yml
+++ b/tests/render_test.yml
@@ -1,0 +1,70 @@
+---
+# Renders neon-hub.yml.j2 for each host profile and asserts the audio wiring
+# (/dev/snd device binds and pulse cookie mounts) appears only when the host
+# has sound support. Run with: ansible-playbook tests/render_test.yml
+- name: Verify compose template renders correctly per host profile
+  hosts: localhost
+  gather_facts: false
+  vars:
+    template_path: "{{ playbook_dir }}/../debos/overlays/ansible/templates/neon-hub.yml.j2"
+    # Stubs for unrelated template variables
+    common_name: test-hub.local
+    docker_gid: 999
+    neon_home: /home/neon
+    xdg_dir: /home/neon/xdg
+    users:
+      neon_skill_config:
+        password: test
+      simple_docker_manager:
+        password: test
+    profiles:
+      - name: linux with audio
+        tvars: {ansible_system: Linux, ansible_os_family: Debian, hub_has_audio: true}
+        dev_snd: 4
+        pulse_cookie: 8
+      - name: linux headless (detected)
+        tvars: {ansible_system: Linux, ansible_os_family: Debian, hub_has_audio: false}
+        dev_snd: 0
+        pulse_cookie: 0
+      - name: linux headless (string extra-var)
+        tvars: {ansible_system: Linux, ansible_os_family: Debian, hub_has_audio: "false"}
+        dev_snd: 0
+        pulse_cookie: 0
+      - name: linux undetected (debos image build)
+        tvars: {ansible_system: Linux, ansible_os_family: Debian}
+        dev_snd: 4
+        pulse_cookie: 8
+      - name: macos
+        tvars: {ansible_system: Darwin, ansible_os_family: Darwin}
+        dev_snd: 0
+        pulse_cookie: 0
+  tasks:
+    - name: Render template for each profile
+      ansible.builtin.set_fact:
+        renders: "{{ renders | default({}) | combine({item.name: lookup('ansible.builtin.template', template_path, template_vars=item.tvars)}) }}"
+      loop: "{{ profiles }}"
+      loop_control:
+        label: "{{ item.name }}"
+
+    - name: Assert rendered output is valid YAML
+      ansible.builtin.assert:
+        that:
+          - renders[item.name] | from_yaml is mapping
+        fail_msg: "Profile '{{ item.name }}' rendered invalid YAML"
+      loop: "{{ profiles }}"
+      loop_control:
+        label: "{{ item.name }}"
+
+    - name: Assert audio wiring matches each profile
+      ansible.builtin.assert:
+        that:
+          - renders[item.name] | regex_findall('/dev/snd') | length == item.dev_snd
+          - renders[item.name] | regex_findall('pulse/cookie') | length == item.pulse_cookie
+        fail_msg: >-
+          Profile '{{ item.name }}' expected {{ item.dev_snd }} /dev/snd and
+          {{ item.pulse_cookie }} pulse/cookie references, got
+          {{ renders[item.name] | regex_findall('/dev/snd') | length }} and
+          {{ renders[item.name] | regex_findall('pulse/cookie') | length }}
+      loop: "{{ profiles }}"
+      loop_control:
+        label: "{{ item.name }}"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,2 @@
+ansible-core~=2.21
+ansible-lint~=26.6


### PR DESCRIPTION
## Summary

- Cloud-optimized kernels (AWS `linux-aws` and similar) ship without ALSA. `/dev/snd` never exists and cannot be created with modprobe, so `docker compose up` fails the speech, audio, enclosure, and skills containers with `error gathering device information while adding custom device "/dev/snd": not a device node`. The pulse cookie bind mounts fail the same way since headless hosts run no PulseAudio.
- `hub.yaml` now probes `/dev/snd/timer` on live installs and the compose template gates the device binds and pulse cookie mounts on the result. debos image builds skip the probe and keep audio wiring, since the build environment lacks `/dev/snd` while the target hardware has it. `-e hub_has_audio=true/false` overrides detection either way.
- Found deploying a Hub to EC2 (m6i.xlarge, Ubuntu 24.04) while following `docs/cloud-vps.md`. The guide now documents the behavior. Nothing is lost on a cloud Hub in practice: STT, TTS, and wake word are served to Nodes over the network, and the host has no mic or speaker to drive.

Since the bug was pure template logic, this also adds the repo's first CI:

- `tests/render_test.yml` renders the compose template across five host profiles (Linux with audio, headless detected, headless via string extra-var, undetected as in debos builds, macOS) and asserts the audio wiring appears only where it should
- ansible-lint at the basic profile, with a generated baseline for pre-existing findings so only new issues fail; debos recipes and `windows/` are excluded since they are Go-templated YAML, not Ansible
- syntax check on `hub.yaml`
- pip and galaxy installs pinned and cached

## Test plan

- [x] Render test passes on all five profiles and fails if the `| bool` cast is removed (string extra-vars are truthy in raw Jinja)
- [x] `ansible-playbook --syntax-check` passes
- [x] Equivalent change (a compose override removing the same device binds and cookie mounts) verified on a live EC2 deploy; full installer run completed with `failed=0` and the stack healthy
- [ ] Regression check on a Hub with real audio hardware (expects no diff in the rendered compose file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)